### PR TITLE
attention.py get_cuda_arch_safe speedup

### DIFF
--- a/comfy/ldm/modules/attention.py
+++ b/comfy/ldm/modules/attention.py
@@ -33,7 +33,7 @@ def get_cuda_arch_safe():
     except Exception as e:
         logging.warning(f"Could not determine GPU arch: {e}")
         return None
-    
+
 
 def install_sageattention_if_needed():
     arch = get_cuda_arch_safe()
@@ -146,7 +146,6 @@ def get_attention_function(name: str, default: Any=...) -> Union[Callable, None]
             return default
     return REGISTERED_ATTENTION_FUNCTIONS[name]
 
-from comfy.cli_args import args
 import comfy.ops
 ops = comfy.ops.disable_weight_init
 

--- a/comfy/ldm/modules/attention.py
+++ b/comfy/ldm/modules/attention.py
@@ -20,14 +20,16 @@ import comfy.ops
 ops = comfy.ops.disable_weight_init
 
 
+_cuda_arch_cache = None
 def get_cuda_arch_safe():
+    global _cuda_arch_cache
+    if _cuda_arch_cache is not None:
+        return _cuda_arch_cache
     try:
-        result = subprocess.check_output([
-            sys.executable,
-            "-c",
-            "import torch; print(torch.cuda.get_device_capability()[0])"
-        ], stderr=subprocess.DEVNULL).decode().strip()
-        return int(result)
+        if not torch.cuda.is_available():
+            return None
+        _cuda_arch_cache = torch.cuda.get_device_capability()[0]
+        return _cuda_arch_cache
     except Exception as e:
         logging.warning(f"Could not determine GPU arch: {e}")
         return None


### PR DESCRIPTION
-4 секунды coldstart

`get_cuda_arch_safe` каждый раз вызывает import torch, ~2 секунды каждый

```
def get_cuda_arch_safe():
    try:
        result = subprocess.check_output([
            sys.executable,
            "-c",
            "import torch; print(torch.cuda.get_device_capability()[0])"
        ], stderr=subprocess.DEVNULL).decode().strip()
        return int(result)
```

Время импортов до:

<img width="1507" height="585" alt="image" src="https://github.com/user-attachments/assets/3c748564-b51e-4537-8dcb-2f6c4967118f" />


Время импортов после:

<img width="1507" height="585" alt="image" src="https://github.com/user-attachments/assets/617dcdb6-4fb7-4dcf-8fb3-5b45fb86a7c6" />
